### PR TITLE
IOS-5792: Add SPM dependencies support

### DIFF
--- a/BinanceChain.podspec
+++ b/BinanceChain.podspec
@@ -19,13 +19,14 @@ Pod::Spec.new do |s|
   s.static_framework = false
 
   s.subspec 'Core' do |sub|
+    # 'SwiftProtobuf' dependency must be added via SPM
+
     sub.source_files = 'BinanceChain/Sources/Core/*.swift'
     sub.dependency 'BinanceChain/Protobuf'
     sub.dependency 'BinanceChain/Util'
     sub.dependency 'BinanceChain/Libraries'
     sub.dependency 'Alamofire'
     sub.dependency 'SwiftyJSON'
-    sub.dependency 'SwiftProtobuf'
     sub.dependency 'SwiftDate'
   end
 


### PR DESCRIPTION
[IOS-5792](https://tangem.atlassian.net/browse/IOS-5792)

Убрана CocoaPods зависимость `SwiftProtobuf` в подспеке (теперь она подключается через SPM потребителем)

[IOS-5792]: https://tangem.atlassian.net/browse/IOS-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ